### PR TITLE
Fix CircleCI chromedriver

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,11 @@ jobs:
           command: |
             bundle install --jobs=4 --retry=3 --path vendor/bundle
 
+      - run:
+          name: Set Chromedriver Version
+          command: |
+            chromedriver-update 2.37
+
       # Project setup
       - run:
           name: Setup Project to Run


### PR DESCRIPTION
Circle CI's container ships with chrome 64 and the latest chromedriver
requires chrome >=65